### PR TITLE
Allow selection of additional dependency groups - fix #44

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
@@ -26,10 +26,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade . -r dev-requirements.txt
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python
       - name: Execute all pre-commit hooks on all files ☑
-        if: matrix.python-version != '3.11'
-        # cf. https://github.com/PyCQA/pylint/issues/7972#issuecomment-1370602977
         run: pre-commit run --all-files
       - name: Running tests ☑
         run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.pyc
 /pre_commit_hooks_safety.egg-info
 /.cache/
-/.coverage
+**/.coverage
+/venv/
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 **/.coverage
 /venv/
 /.idea/
+build/

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Note that **telemetry data will be sent with every Safety call**. These data are
 ```
 
 ## How to Use Arguments
-There are a few different arguements that this hook will accept.
+There are a few different arguments that this hook will accept.
 
-The first is the `files` arguement. Simply put which file your dependancies are listed in.
+The first is the `files` argument. Simply put which file your dependencies are listed in.
 ```yaml
 -   repo: https://github.com/Lucas-C/pre-commit-hooks-safety
     rev: v1.3.1
@@ -35,7 +35,15 @@ The next is the `--ignore` flag. This will ignore a comma seperated list of know
     -   id: python-safety-dependencies-check
         args: ["--ignore=39153,39652"]
 ```
-You can also select between `--full-report` and `--short-report`. By default safety will use the `--full-report` flag so you can omit it for cleaner code.
+The `--groups` flag will allow you to select additional dependency groups, other than the implicit main group. An example:
+```yaml
+-   repo: https://github.com/Lucas-C/pre-commit-hooks-safety
+    rev: v1.3.1
+    hooks:
+    -   id: python-safety-dependencies-check
+        args: ["--groups=dev,test"]
+```
+You can also select between `--full-report` and `--short-report`. By default, safety will use the `--full-report` flag so you can omit it for cleaner code.
 ```yaml
 -   repo: https://github.com/Lucas-C/pre-commit-hooks-safety
     rev: v1.3.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ pre-commit
 pylint
 pytest
 pytest-cov
+poetry

--- a/tests/safety_test.py
+++ b/tests/safety_test.py
@@ -66,7 +66,6 @@ def test_poetry_requirements(tmpdir):  # cf. https://github.com/Lucas-C/pre-comm
 colored-traceback==0.3.0 \
     --hash=sha256:6da7ce2b1da869f6bb54c927b415b95727c4bb6d9a84c4615ea77d9872911b05 \
     --hash=sha256:f76c21a4b4c72e9e09763d4d1b234afc469c88693152a763ad6786467ef9e79f
-configobj==5.0.6
 future==0.18.3
 six==1.13.0 \
     --hash=sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd \
@@ -90,7 +89,9 @@ def test_pyproject_toml_without_deps(tmpdir):
 name = 'Thing'
 version = '1.2.3'
 description = 'Dummy'
-authors = ['Lucas Cimon']""")
+authors = ['Lucas Cimon']
+[tool.poetry.dev-dependencies]
+""")
     assert safety([str(pyproject_file)]) == 0
 
 def test_pyproject_toml_with_ko_deps(tmpdir):
@@ -103,7 +104,10 @@ authors = ['Lucas Cimon']
 
 [tool.poetry.dependencies]
 python = "^3.7"
-jsonpickle = '1.4.1'""")
+jsonpickle = '1.4.1'
+
+[tool.poetry.dev-dependencies]
+""")
     assert safety([str(pyproject_file)]) == EXIT_CODE_VULNERABILITIES_FOUND
 
 def test_pyproject_toml_with_ko_dev_deps(tmpdir):


### PR DESCRIPTION
Modified the `build_parser()` and `convert_poetry_to_requirements()` functions to allow for the selection of additional dependency groups.

With this PR, the `dev` group is no longer automatically selected, which is a change in behaviour compared to previous version, but will avoid errors on projects that do not have this group.