### PR TITLE
Update to work with Poetry 2.0.0

### DIFF
--- a/pre_commit_hooks/safety_check.py
+++ b/pre_commit_hooks/safety_check.py
@@ -48,7 +48,16 @@ def main(argv=None):  # pylint: disable=inconsistent-return-statements
         pyproject_toml_filepath = files[0]
         with pyproject_toml_filepath.open() as pyproject_file:
             lines = [line.strip() for line in pyproject_file.readlines()]
-        if any(line.startswith("[tool.poetry]") for line in lines):
+
+        poetry_project = any(
+            (
+                line.startswith("[tool.poetry")
+                or "poetry-core" in line or
+                "poetry.core.masonry.api" in line
+            )
+            for line in lines
+        )
+        if poetry_project:
             with convert_poetry_to_requirements(pyproject_toml_filepath, groups=parsed_args.groups) as tmp_requirements:
                 return call_safety_check([tmp_requirements.name], parsed_args.ignore, parsed_args.report_arg, args_rest)
         parser.error("Unsupported build tool: this pre-commit hook currently only handles pyproject.toml with Poetry"

--- a/tests/safety_test.py
+++ b/tests/safety_test.py
@@ -258,5 +258,9 @@ colored = "1.4.2"
 
 [tool.poetry.group.test.dependencies]
 insecure-package = "0.1.0"
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"
 """)
     assert safety([str(pyproject_file), group_arg]) == status


### PR DESCRIPTION
This PR makes checking for Poetry `pyproject.toml` more flexible, in order to also work with Poetry 2.0.0, which uses PEP-compliant format.

It is technically possible to use Poetry and not have any `[tool.poetry.xxx]` section now, so now it checks for either this or Poetry build system (`poetry-core` or `poetry.core.masonry.api`).