### PR TITLE
Add more robust requirements path check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/),
 and [PEP 440](https://www.python.org/dev/peps/pep-0440/).
 
+## [1.4.1] - 2025-02-05
+### Added
+- Add more robust requirements path check - _cf._ [PR #55](https://github.com/Lucas-C/pre-commit-hooks-safety/pull/59)
 
 ## [1.4.0] - 2025-02-05
 ### Added

--- a/pre_commit_hooks/safety_check.py
+++ b/pre_commit_hooks/safety_check.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import argparse
 import os
 import sys
@@ -41,9 +39,14 @@ def build_parser():
 def main(argv=None):  # pylint: disable=inconsistent-return-statements
     parser = build_parser()
     parsed_args, args_rest = parser.parse_known_args(argv)
-    if all("requirements" in file_path for file_path in parsed_args.files):
-        return call_safety_check(parsed_args.files, parsed_args.ignore, parsed_args.report_arg, args_rest)
+
     files = [Path(f) for f in parsed_args.files]
+    if all(
+        "requirements" in file_path.name and file_path.name.endswith(".txt")
+        for file_path in files
+    ):
+        return call_safety_check(parsed_args.files, parsed_args.ignore, parsed_args.report_arg, args_rest)
+
     if len(files) == 1 and files[0].name == "pyproject.toml":
         pyproject_toml_filepath = files[0]
         with pyproject_toml_filepath.open() as pyproject_file:

--- a/tests/safety_test.py
+++ b/tests/safety_test.py
@@ -11,7 +11,7 @@ def test_dev_requirements():
 
 def test_non_ok_dependency(tmp_path):
     requirements_file = tmp_path / "requirements.txt"
-    with open(requirements_file, "w") as file:
+    with open(requirements_file, "w", encoding="utf-8") as file:
         file.write("urllib3==1.24.1")
 
     assert safety([str(requirements_file)]) == EXIT_CODE_VULNERABILITIES_FOUND
@@ -19,7 +19,7 @@ def test_non_ok_dependency(tmp_path):
 
 def test_short_report(tmp_path):
     requirements_file = tmp_path / "requirements.txt"
-    with open(requirements_file, "w") as file:
+    with open(requirements_file, "w", encoding="utf-8") as file:
         file.write("urllib3==1.24.1")
 
     assert safety(["--short-report", str(requirements_file)]) == EXIT_CODE_VULNERABILITIES_FOUND
@@ -27,7 +27,7 @@ def test_short_report(tmp_path):
 
 def test_disable_telemetry(tmp_path):
     requirements_file = tmp_path / "requirements.txt"
-    with open(requirements_file, "w") as file:
+    with open(requirements_file, "w", encoding="utf-8") as file:
         file.write("urllib3==1.24.1")
 
     assert safety(["--disable-optional-telemetry", str(requirements_file)]) == EXIT_CODE_VULNERABILITIES_FOUND
@@ -36,7 +36,7 @@ def test_disable_telemetry(tmp_path):
 @pytest.mark.parametrize("report", [["--full-report"], []])
 def test_full_report(tmp_path, report, capfd):
     requirements_file = tmp_path / "requirements.txt"
-    with open(requirements_file, "w") as file:
+    with open(requirements_file, "w", encoding="utf-8") as file:
         file.write("urllib3==1.24.1")
 
     assert safety(report + [str(requirements_file)]) == EXIT_CODE_VULNERABILITIES_FOUND
@@ -55,7 +55,7 @@ def test_full_report(tmp_path, report, capfd):
 )
 def test_ignore_ok(capfd, tmp_path, args):
     requirements_file = tmp_path / "requirements.txt"
-    with open(requirements_file, "w") as file:
+    with open(requirements_file, "w", encoding="utf-8") as file:
         file.write("urllib3==1.24.1")
 
     assert safety([str(requirements_file)] + args) == 0, capfd.readouterr()
@@ -73,7 +73,7 @@ def test_ignore_ok(capfd, tmp_path, args):
 )
 def test_varargs_escape(tmp_path, ignore_arg, status):
     requirements_file = tmp_path / "requirements.txt"
-    with open(requirements_file, "w") as file:
+    with open(requirements_file, "w", encoding="utf-8") as file:
         file.write("urllib3==1.24.1")
 
     assert safety([ignore_arg, "--", str(requirements_file)]) == status
@@ -81,7 +81,7 @@ def test_varargs_escape(tmp_path, ignore_arg, status):
 
 def test_poetry_requirements(tmp_path):  # cf. https://github.com/Lucas-C/pre-commit-hooks-safety/issues/5
     requirements_file = tmp_path / "requirements.txt"
-    with open(requirements_file, "w") as file:
+    with open(requirements_file, "w", encoding="utf-8") as file:
         file.write("""colored==1.4.2
 colored-traceback==0.3.0 \
     --hash=sha256:6da7ce2b1da869f6bb54c927b415b95727c4bb6d9a84c4615ea77d9872911b05 \
@@ -96,7 +96,7 @@ six==1.13.0 \
 
 def test_editable_url_to_tarball_dependency(tmp_path):
     requirements_file = tmp_path / "requirements.txt"
-    with open(requirements_file, "w") as file:
+    with open(requirements_file, "w", encoding="utf-8") as file:
         file.write(
             "-e https://files.pythonhosted.org/packages/6a/11/114c67b0e3c25c19497fde977538339530d8ffa050d6ec9349793f933faa/lockfile-0.10.2.tar.gz"
         )
@@ -107,7 +107,7 @@ def test_editable_url_to_tarball_dependency(tmp_path):
 @pytest.mark.xfail(reason="cf. https://github.com/Lucas-C/pre-commit-hooks-safety/issues/1")
 def test_bare_url_to_tarball_dependency(tmp_path):
     requirements_file = tmp_path / "requirements.txt"
-    with open(requirements_file, "w") as file:
+    with open(requirements_file, "w", encoding="utf-8") as file:
         file.write(
             "https://files.pythonhosted.org/packages/6a/11/114c67b0e3c25c19497fde977538339530d8ffa050d6ec9349793f933faa/lockfile-0.10.2.tar.gz"
         )
@@ -117,7 +117,7 @@ def test_bare_url_to_tarball_dependency(tmp_path):
 
 def test_pyproject_toml_without_deps(tmp_path):
     pyproject_file = tmp_path / "pyproject.toml"
-    with open(pyproject_file, "w") as file:
+    with open(pyproject_file, "w", encoding="utf-8") as file:
         file.write("""[tool.poetry]
 name = "Thing"
 version = "1.2.3"
@@ -129,7 +129,7 @@ authors = ["Lucas Cimon"]
 
 def test_pyproject_toml_pep_621_format(tmp_path):
     pyproject_file = tmp_path / "pyproject.toml"
-    with open(pyproject_file, "w") as file:
+    with open(pyproject_file, "w", encoding="utf-8") as file:
         file.write("""[project]
 name = "Thing"
 version = "1.2.3"
@@ -145,7 +145,7 @@ build-backend = "poetry.core.masonry.api"
 
 def test_pyproject_toml_with_ko_deps(tmp_path):
     pyproject_file = tmp_path / "pyproject.toml"
-    with open(pyproject_file, "w") as file:
+    with open(pyproject_file, "w", encoding="utf-8") as file:
         file.write("""[tool.poetry]
 name = "Thing"
 version = "1.2.3"
@@ -161,7 +161,7 @@ jubatus = "1.0.2"
 
 def test_pyproject_toml_pep_621_format_with_ko_deps(tmp_path):
     pyproject_file = tmp_path / "pyproject.toml"
-    with open(pyproject_file, "w") as file:
+    with open(pyproject_file, "w", encoding="utf-8") as file:
         file.write("""[project]
 name = "Thing"
 version = "1.2.3"
@@ -181,7 +181,7 @@ build-backend = "poetry.core.masonry.api"
 
 def test_pyproject_toml_pep_621_dynamic_format_with_ko_deps(tmp_path):
     pyproject_file = tmp_path / "pyproject.toml"
-    with open(pyproject_file, "w") as file:
+    with open(pyproject_file, "w", encoding="utf-8") as file:
         file.write("""[project]
 name = "Thing"
 version = "1.2.3"
@@ -203,7 +203,7 @@ build-backend = "poetry.core.masonry.api"
 
 def test_pyproject_toml_with_ko_dev_deps(tmp_path):
     pyproject_file = tmp_path / "pyproject.toml"
-    with open(pyproject_file, "w") as file:
+    with open(pyproject_file, "w", encoding="utf-8") as file:
         file.write("""[tool.poetry]
 name = "Thing"
 version = "1.2.3"
@@ -222,7 +222,7 @@ jubatus = "1.0.2"
 
 def test_pyproject_toml_pep_621_with_ko_dev_deps(tmp_path):
     pyproject_file = tmp_path / "pyproject.toml"
-    with open(pyproject_file, "w") as file:
+    with open(pyproject_file, "w", encoding="utf-8") as file:
         file.write("""[project]
 name = "Thing"
 version = "1.2.3"
@@ -251,7 +251,7 @@ build-backend = "poetry.core.masonry.api"
 )
 def test_pyproject_toml_with_groups(tmp_path, group_arg, status):
     pyproject_file = tmp_path / "pyproject.toml"
-    with open(pyproject_file, "w") as file:
+    with open(pyproject_file, "w", encoding="utf-8") as file:
         file.write("""[tool.poetry]
 name = "Thing"
 version = "1.2.3"
@@ -281,7 +281,7 @@ insecure-package = "0.1.0"
 )
 def test_pyproject_toml_pep_621_format_with_groups(tmp_path, group_arg, status):
     pyproject_file = tmp_path / "pyproject.toml"
-    with open(pyproject_file, "w") as file:
+    with open(pyproject_file, "w", encoding="utf-8") as file:
         file.write("""[project]
 name = "Thing"
 version = "1.2.3"
@@ -306,11 +306,11 @@ build-backend = "poetry.core.masonry.api"
 def test_allow_dir_with_requirements_in_name(tmp_path):
     dir_path = tmp_path / "src_requirements_dir"
     dir_path.mkdir(exist_ok=True)
-    with open(dir_path / "dummy_file.py", "w") as file:
-        file.write("# this is a commnent")
+    with open(dir_path / "dummy_file.py", "w", encoding="utf-8") as file:
+        file.write("# this is a comment")
 
     pyproject_file = tmp_path / "pyproject.toml"
-    with open(pyproject_file, "w") as file:
+    with open(pyproject_file, "w", encoding="utf-8") as file:
         file.write("""[tool.poetry]
 name = "Thing"
 version = "1.2.3"
@@ -323,11 +323,11 @@ authors = ["Lucas Cimon"]
 def test_allow_file_with_requirements_in_name(tmp_path):
     dir_path = tmp_path / "src"
     dir_path.mkdir(exist_ok=True)
-    with open(dir_path / "create_requirements.py", "w") as file:
-        file.write("# this is a commnent")
+    with open(dir_path / "create_requirements.py", "w", encoding="utf-8") as file:
+        file.write("# this is a comment")
 
     pyproject_file = tmp_path / "pyproject.toml"
-    with open(pyproject_file, "w") as file:
+    with open(pyproject_file, "w", encoding="utf-8") as file:
         file.write("""[tool.poetry]
 name = "Thing"
 version = "1.2.3"

--- a/tests/safety_test.py
+++ b/tests/safety_test.py
@@ -1,7 +1,4 @@
 # pylint: disable=invalid-name,line-too-long
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import pytest
 from safety.constants import EXIT_CODE_VULNERABILITIES_FOUND
 
@@ -9,43 +6,60 @@ from pre_commit_hooks.safety_check import main as safety
 
 
 def test_dev_requirements():
-    assert safety(['dev-requirements.txt']) == 0
+    assert safety(["dev-requirements.txt"]) == 0
 
-def test_non_ok_dependency(tmpdir):
-    requirements_file = tmpdir.join('requirements.txt')
-    requirements_file.write('urllib3==1.24.1')
+
+def test_non_ok_dependency(tmp_path):
+    requirements_file = tmp_path / "requirements.txt"
+    with open(requirements_file, "w") as file:
+        file.write("urllib3==1.24.1")
+
     assert safety([str(requirements_file)]) == EXIT_CODE_VULNERABILITIES_FOUND
 
-def test_short_report(tmpdir):
-    requirements_file = tmpdir.join('requirements.txt')
-    requirements_file.write('urllib3==1.24.1')
+
+def test_short_report(tmp_path):
+    requirements_file = tmp_path / "requirements.txt"
+    with open(requirements_file, "w") as file:
+        file.write("urllib3==1.24.1")
+
     assert safety(["--short-report", str(requirements_file)]) == EXIT_CODE_VULNERABILITIES_FOUND
 
-def test_disable_telemetry(tmpdir):
-    requirements_file = tmpdir.join('requirements.txt')
-    requirements_file.write('urllib3==1.24.1')
+
+def test_disable_telemetry(tmp_path):
+    requirements_file = tmp_path / "requirements.txt"
+    with open(requirements_file, "w") as file:
+        file.write("urllib3==1.24.1")
+
     assert safety(["--disable-optional-telemetry", str(requirements_file)]) == EXIT_CODE_VULNERABILITIES_FOUND
 
+
 @pytest.mark.parametrize("report", [["--full-report"], []])
-def test_full_report(tmpdir, report, capfd):
-    requirements_file = tmpdir.join('requirements.txt')
-    requirements_file.write('urllib3==1.24.1')
+def test_full_report(tmp_path, report, capfd):
+    requirements_file = tmp_path / "requirements.txt"
+    with open(requirements_file, "w") as file:
+        file.write("urllib3==1.24.1")
+
     assert safety(report + [str(requirements_file)]) == EXIT_CODE_VULNERABILITIES_FOUND
     output = capfd.readouterr().out
     assert "urllib3" in output
     assert "1.24.1" in output
 
+
 @pytest.mark.parametrize(
     "args",
     [
         ["--ignore=37055,37071,38834,43975,61601,61893,71562,71608"],
-        ['--ignore=37055', '--ignore=37071', '--ignore=38834', '--ignore=43975', '--ignore=61601', '--ignore=61893', '--ignore=71562', '--ignore=71608'],
+        ["--ignore=37055", "--ignore=37071", "--ignore=38834", "--ignore=43975", "--ignore=61601", "--ignore=61893",
+         "--ignore=71562", "--ignore=71608"],
     ]
 )
-def test_ignore_ok(capfd, tmpdir, args):
-    requirements_file = tmpdir.join('requirements.txt')
-    requirements_file.write('urllib3==1.24.1')
+def test_ignore_ok(capfd, tmp_path, args):
+    requirements_file = tmp_path / "requirements.txt"
+    with open(requirements_file, "w") as file:
+        file.write("urllib3==1.24.1")
+
     assert safety([str(requirements_file)] + args) == 0, capfd.readouterr()
+
 
 @pytest.mark.parametrize(
     "ignore_arg,status",
@@ -57,48 +71,66 @@ def test_ignore_ok(capfd, tmpdir, args):
         ("--ignore=38834", EXIT_CODE_VULNERABILITIES_FOUND),
     ]
 )
-def test_varargs_escape(tmpdir, ignore_arg, status):
-    requirements_file = tmpdir.join('requirements.txt')
-    requirements_file.write('urllib3==1.24.1')
+def test_varargs_escape(tmp_path, ignore_arg, status):
+    requirements_file = tmp_path / "requirements.txt"
+    with open(requirements_file, "w") as file:
+        file.write("urllib3==1.24.1")
+
     assert safety([ignore_arg, "--", str(requirements_file)]) == status
 
-def test_poetry_requirements(tmpdir):  # cf. https://github.com/Lucas-C/pre-commit-hooks-safety/issues/5
-    requirements_file = tmpdir.join('requirements.txt')
-    requirements_file.write('''colored==1.4.2
+
+def test_poetry_requirements(tmp_path):  # cf. https://github.com/Lucas-C/pre-commit-hooks-safety/issues/5
+    requirements_file = tmp_path / "requirements.txt"
+    with open(requirements_file, "w") as file:
+        file.write("""colored==1.4.2
 colored-traceback==0.3.0 \
     --hash=sha256:6da7ce2b1da869f6bb54c927b415b95727c4bb6d9a84c4615ea77d9872911b05 \
     --hash=sha256:f76c21a4b4c72e9e09763d4d1b234afc469c88693152a763ad6786467ef9e79f
 future==0.18.3
 six==1.13.0 \
     --hash=sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd \
-    --hash=sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66''')
+    --hash=sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"""
+                   )
     assert safety([str(requirements_file)]) == 0
 
-def test_editable_url_to_tarball_dependency(tmpdir):
-    requirements_file = tmpdir.join('requirements.txt')
-    requirements_file.write('-e https://files.pythonhosted.org/packages/6a/11/114c67b0e3c25c19497fde977538339530d8ffa050d6ec9349793f933faa/lockfile-0.10.2.tar.gz')
+
+def test_editable_url_to_tarball_dependency(tmp_path):
+    requirements_file = tmp_path / "requirements.txt"
+    with open(requirements_file, "w") as file:
+        file.write(
+            "-e https://files.pythonhosted.org/packages/6a/11/114c67b0e3c25c19497fde977538339530d8ffa050d6ec9349793f933faa/lockfile-0.10.2.tar.gz"
+        )
+
     assert safety([str(requirements_file)]) == 0
 
-@pytest.mark.xfail(reason='cf. https://github.com/Lucas-C/pre-commit-hooks-safety/issues/1')
-def test_bare_url_to_tarball_dependency(tmpdir):
-    requirements_file = tmpdir.join('requirements.txt')
-    requirements_file.write('https://files.pythonhosted.org/packages/6a/11/114c67b0e3c25c19497fde977538339530d8ffa050d6ec9349793f933faa/lockfile-0.10.2.tar.gz')
+
+@pytest.mark.xfail(reason="cf. https://github.com/Lucas-C/pre-commit-hooks-safety/issues/1")
+def test_bare_url_to_tarball_dependency(tmp_path):
+    requirements_file = tmp_path / "requirements.txt"
+    with open(requirements_file, "w") as file:
+        file.write(
+            "https://files.pythonhosted.org/packages/6a/11/114c67b0e3c25c19497fde977538339530d8ffa050d6ec9349793f933faa/lockfile-0.10.2.tar.gz"
+        )
+
     assert safety([str(requirements_file)]) == 0
 
-def test_pyproject_toml_without_deps(tmpdir):
-    pyproject_file = tmpdir.join('pyproject.toml')
-    pyproject_file.write("""[tool.poetry]
-name = 'Thing'
-version = '1.2.3'
-description = 'Dummy'
-authors = ['Lucas Cimon']
+
+def test_pyproject_toml_without_deps(tmp_path):
+    pyproject_file = tmp_path / "pyproject.toml"
+    with open(pyproject_file, "w") as file:
+        file.write("""[tool.poetry]
+name = "Thing"
+version = "1.2.3"
+description = "Dummy"
+authors = ["Lucas Cimon"]
 """)
     assert safety([str(pyproject_file)]) == 0
 
 
-def test_pyproject_toml_pep_621_format(tmpdir):
-    pyproject_file = tmpdir.join('pyproject.toml')
-    pyproject_file.write("""[project]
+def test_pyproject_toml_pep_621_format(tmp_path):
+    pyproject_file = tmp_path / "pyproject.toml"
+    with open(pyproject_file, "w") as file:
+        file.write("""[project]
 name = "Thing"
 version = "1.2.3"
 description = "Dummy"
@@ -111,24 +143,26 @@ build-backend = "poetry.core.masonry.api"
     assert safety([str(pyproject_file)]) == 0
 
 
-def test_pyproject_toml_with_ko_deps(tmpdir):
-    pyproject_file = tmpdir.join('pyproject.toml')
-    pyproject_file.write("""[tool.poetry]
-name = 'Thing'
-version = '1.2.3'
-description = 'Dummy'
-authors = ['Lucas Cimon']
+def test_pyproject_toml_with_ko_deps(tmp_path):
+    pyproject_file = tmp_path / "pyproject.toml"
+    with open(pyproject_file, "w") as file:
+        file.write("""[tool.poetry]
+name = "Thing"
+version = "1.2.3"
+description = "Dummy"
+authors = ["Lucas Cimon"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-jubatus = '1.0.2'
+jubatus = "1.0.2"
 """)
     assert safety([str(pyproject_file)]) == EXIT_CODE_VULNERABILITIES_FOUND
 
 
-def test_pyproject_toml_pep_621_format_with_ko_deps(tmpdir):
-    pyproject_file = tmpdir.join('pyproject.toml')
-    pyproject_file.write("""[project]
+def test_pyproject_toml_pep_621_format_with_ko_deps(tmp_path):
+    pyproject_file = tmp_path / "pyproject.toml"
+    with open(pyproject_file, "w") as file:
+        file.write("""[project]
 name = "Thing"
 version = "1.2.3"
 description = "Dummy"
@@ -145,9 +179,10 @@ build-backend = "poetry.core.masonry.api"
     assert safety([str(pyproject_file)]) == EXIT_CODE_VULNERABILITIES_FOUND
 
 
-def test_pyproject_toml_pep_621_dynamic_format_with_ko_deps(tmpdir):
-    pyproject_file = tmpdir.join('pyproject.toml')
-    pyproject_file.write("""[project]
+def test_pyproject_toml_pep_621_dynamic_format_with_ko_deps(tmp_path):
+    pyproject_file = tmp_path / "pyproject.toml"
+    with open(pyproject_file, "w") as file:
+        file.write("""[project]
 name = "Thing"
 version = "1.2.3"
 description = "Dummy"
@@ -166,28 +201,29 @@ build-backend = "poetry.core.masonry.api"
     assert safety([str(pyproject_file)]) == EXIT_CODE_VULNERABILITIES_FOUND
 
 
-
-def test_pyproject_toml_with_ko_dev_deps(tmpdir):
-    pyproject_file = tmpdir.join('pyproject.toml')
-    pyproject_file.write("""[tool.poetry]
-name = 'Thing'
-version = '1.2.3'
-description = 'Dummy'
-authors = ['Lucas Cimon']
+def test_pyproject_toml_with_ko_dev_deps(tmp_path):
+    pyproject_file = tmp_path / "pyproject.toml"
+    with open(pyproject_file, "w") as file:
+        file.write("""[tool.poetry]
+name = "Thing"
+version = "1.2.3"
+description = "Dummy"
+authors = ["Lucas Cimon"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
 
 # Poetry pre-1.2.x style
 [tool.poetry.dev-dependencies]
-jubatus = '1.0.2'
+jubatus = "1.0.2"
 """)
     assert safety([str(pyproject_file), "--groups=dev"]) == EXIT_CODE_VULNERABILITIES_FOUND
 
 
-def test_pyproject_toml_pep_621_with_ko_dev_deps(tmpdir):
-    pyproject_file = tmpdir.join('pyproject.toml')
-    pyproject_file.write("""[project]
+def test_pyproject_toml_pep_621_with_ko_dev_deps(tmp_path):
+    pyproject_file = tmp_path / "pyproject.toml"
+    with open(pyproject_file, "w") as file:
+        file.write("""[project]
 name = "Thing"
 version = "1.2.3"
 description = "Dummy"
@@ -205,7 +241,6 @@ build-backend = "poetry.core.masonry.api"
     assert safety([str(pyproject_file), "--groups=dev"]) == EXIT_CODE_VULNERABILITIES_FOUND
 
 
-
 @pytest.mark.parametrize(
     "group_arg,status",
     [
@@ -214,13 +249,14 @@ build-backend = "poetry.core.masonry.api"
         ("--groups=test", EXIT_CODE_VULNERABILITIES_FOUND),
     ]
 )
-def test_pyproject_toml_with_groups(tmpdir, group_arg, status):
-    pyproject_file = tmpdir.join('pyproject.toml')
-    pyproject_file.write("""[tool.poetry]
-name = 'Thing'
-version = '1.2.3'
-description = 'Dummy'
-authors = ['Lucas Cimon']
+def test_pyproject_toml_with_groups(tmp_path, group_arg, status):
+    pyproject_file = tmp_path / "pyproject.toml"
+    with open(pyproject_file, "w") as file:
+        file.write("""[tool.poetry]
+name = "Thing"
+version = "1.2.3"
+description = "Dummy"
+authors = ["Lucas Cimon"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
@@ -230,7 +266,7 @@ python = "^3.9"
 colored = "1.4.2"
 
 [tool.poetry.group.test.dependencies]
-insecure-package = '0.1.0'
+insecure-package = "0.1.0"
 """)
     assert safety([str(pyproject_file), group_arg]) == status
 
@@ -243,9 +279,10 @@ insecure-package = '0.1.0'
         ("--groups=test", EXIT_CODE_VULNERABILITIES_FOUND),
     ]
 )
-def test_pyproject_toml_pep_621_format_with_groups(tmpdir, group_arg, status):
-    pyproject_file = tmpdir.join('pyproject.toml')
-    pyproject_file.write("""[project]
+def test_pyproject_toml_pep_621_format_with_groups(tmp_path, group_arg, status):
+    pyproject_file = tmp_path / "pyproject.toml"
+    with open(pyproject_file, "w") as file:
+        file.write("""[project]
 name = "Thing"
 version = "1.2.3"
 description = "Dummy"
@@ -264,3 +301,37 @@ requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 """)
     assert safety([str(pyproject_file), group_arg]) == status
+
+
+def test_allow_dir_with_requirements_in_name(tmp_path):
+    dir_path = tmp_path / "src_requirements_dir"
+    dir_path.mkdir(exist_ok=True)
+    with open(dir_path / "dummy_file.py", "w") as file:
+        file.write("# this is a commnent")
+
+    pyproject_file = tmp_path / "pyproject.toml"
+    with open(pyproject_file, "w") as file:
+        file.write("""[tool.poetry]
+name = "Thing"
+version = "1.2.3"
+description = "Dummy"
+authors = ["Lucas Cimon"]
+""")
+    assert safety([str(pyproject_file)]) == 0
+
+
+def test_allow_file_with_requirements_in_name(tmp_path):
+    dir_path = tmp_path / "src"
+    dir_path.mkdir(exist_ok=True)
+    with open(dir_path / "create_requirements.py", "w") as file:
+        file.write("# this is a commnent")
+
+    pyproject_file = tmp_path / "pyproject.toml"
+    with open(pyproject_file, "w") as file:
+        file.write("""[tool.poetry]
+name = "Thing"
+version = "1.2.3"
+description = "Dummy"
+authors = ["Lucas Cimon"]
+""")
+    assert safety([str(pyproject_file)]) == 0


### PR DESCRIPTION
Fixes https://github.com/Lucas-C/pre-commit-hooks-safety/issues/58 by making check for `requirements.txt` more robust. It only matches files (and not directories) that have `requirements` in name and it must end with `.txt`. I also had to modify tests quite a bit to create temporary files and directories. They now use `tmp_path` fixture built into PyTest, previous one was long deprecated.