### PR TITLE
Update safety_check.py

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,5 +2,6 @@ pre-commit
 pylint
 pytest
 pytest-cov
+packaging>=24.0
 poetry
 poetry-plugin-export

--- a/pre_commit_hooks/safety_check.py
+++ b/pre_commit_hooks/safety_check.py
@@ -42,7 +42,7 @@ def main(argv=None):  # pylint: disable=inconsistent-return-statements
 
     files = [Path(f) for f in parsed_args.files]
     if all(
-        "requirements" in file_path.name and file_path.name.endswith(".txt")
+        "requirements" in str(file_path) and file_path.name.endswith(".txt")
         for file_path in files
     ):
         return call_safety_check(

--- a/tests/safety_test.py
+++ b/tests/safety_test.py
@@ -137,6 +137,16 @@ def test_bare_url_to_tarball_dependency(tmp_path):
     assert safety([str(requirements_file)]) == 0
 
 
+def test_requirements_txt_directory(tmp_path):
+    requirements_path = tmp_path / "requirements"
+    requirements_path.mkdir(exist_ok=True)
+    requirements_file = requirements_path / "app.txt"
+    with open(requirements_file, "w", encoding="utf-8") as file:    
+        file.write("urllib3==1.24.1")
+
+    assert safety([str(requirements_file)]) == EXIT_CODE_VULNERABILITIES_FOUND
+
+
 def test_pyproject_toml_without_deps(tmp_path):
     pyproject_file = tmp_path / "pyproject.toml"
     with open(pyproject_file, "w", encoding="utf-8") as file:

--- a/tests/safety_test.py
+++ b/tests/safety_test.py
@@ -141,7 +141,7 @@ def test_requirements_txt_directory(tmp_path):
     requirements_path = tmp_path / "requirements"
     requirements_path.mkdir(exist_ok=True)
     requirements_file = requirements_path / "app.txt"
-    with open(requirements_file, "w", encoding="utf-8") as file:    
+    with open(requirements_file, "w", encoding="utf-8") as file:
         file.write("urllib3==1.24.1")
 
     assert safety([str(requirements_file)]) == EXIT_CODE_VULNERABILITIES_FOUND


### PR DESCRIPTION
Fixes issue where the pre-commit hook fails when requirements.txt files are in a directory named "requirements" but do not contain "requirements" in their name.